### PR TITLE
[chore] remove metadata validation requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     }
   },
   "dependencies": {
-    "@zoralabs/media-metadata-schemas": "^0.1.3",
     "big.js": "^6.1.0",
     "cross-fetch": "^3.1.4",
     "dataloader": "^2.0.0",

--- a/src/fetcher/FetchResultTypes.ts
+++ b/src/fetcher/FetchResultTypes.ts
@@ -15,7 +15,6 @@ export type MediaContentType =
 
 export type MetadataResultType = {
   metadata: any;
-  valid: boolean;
 };
 
 export type NFTMediaDataType = {

--- a/src/fetcher/MediaFetchAgent.ts
+++ b/src/fetcher/MediaFetchAgent.ts
@@ -1,6 +1,5 @@
 import DataLoader from 'dataloader';
 import { GraphQLClient } from 'graphql-request';
-import { Validator } from '@zoralabs/media-metadata-schemas';
 
 import { RequestError } from './RequestError';
 import {
@@ -104,14 +103,7 @@ export class MediaFetchAgent {
   async loadMetadata(url: string): Promise<MetadataResultType> {
     const metadata = await this.loaders.metadataLoader.load(url);
 
-    let valid = false;
-    try {
-      const validator = new Validator(metadata.version);
-      valid = validator.validate(metadata);
-    } catch (e) {
-      // skip validator errors
-    }
-    return { metadata, valid };
+    return {metadata};
   }
 
   /**

--- a/src/hooks/useNFTMetadata.ts
+++ b/src/hooks/useNFTMetadata.ts
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import { RequestError } from '../fetcher/RequestError';
 import { useCallbackFetch } from './useCallbackFetch';
 
 export type useNFTMetadataType = {
@@ -19,17 +18,13 @@ export type useNFTMetadataType = {
  */
 export function useNFTMetadata(
   uri: string,
-  { allowInvalid } = { allowInvalid: false }
 ): useNFTMetadataType {
   const [metadata, setMetadata] = useState<any>();
   const [error, setError] = useState<string | undefined>();
 
   useCallbackFetch(uri, async (fetchAgent, uri) => {
     try {
-      const { metadata, valid } = await fetchAgent.loadMetadata(uri);
-      if (!allowInvalid && !valid) {
-        throw new RequestError('Metadata Invalid: Metadata could not be validated.');
-      }
+      const {metadata} = await fetchAgent.loadMetadata(uri);
       setMetadata(metadata);
     } catch (err) {
       setError(err.toString());

--- a/tests/useNFTMetadata.test.ts
+++ b/tests/useNFTMetadata.test.ts
@@ -35,38 +35,6 @@ describe('useNFTContent', () => {
     });
   });
 
-  it('throws an error for invalid metadata', async () => {
-    fetchMock.get('https://ipfs.io/ipfs/IPFS_SHA_EXAMPLE', { name: 'test' });
-
-    const { waitFor, result } = renderHook(() =>
-      useNFTMetadata('https://ipfs.io/ipfs/IPFS_SHA_EXAMPLE')
-    );
-
-    await waitFor(() => result.current.loading === false);
-
-    expect(result.current.error).toEqual(
-      'RequestError: Metadata Invalid: Metadata could not be validated.'
-    );
-    expect(result.current.loading).toBeFalsy();
-    expect(result.current.metadata).toBeUndefined();
-  });
-
-  it('allows invalid metadata when validation exception disabled', async () => {
-    fetchMock.get('https://ipfs.io/ipfs/IPFS_SHA_EXAMPLE', { name: 'test' });
-
-    const { waitFor, result } = renderHook(() =>
-      useNFTMetadata('https://ipfs.io/ipfs/IPFS_SHA_EXAMPLE', { allowInvalid: true })
-    );
-
-    await waitFor(() => result.current.loading === false);
-
-    expect(result.current.error).toBeUndefined();
-    expect(result.current.loading).toBeFalsy();
-    expect(result.current.metadata).toEqual({
-      name: 'test',
-    });
-  });
-
   it('returns error when metadata does not exist', async () => {
     fetchMock.get('https://ipfs.io/ipfs/IPFS_SHA_EXAMPLE', 'Not Found', {
       response: { status: 404 },


### PR DESCRIPTION
Due to the way the API is structured from the zora-metdata validator validation fails when a version is not passed in. however, a version is not required of the metadata and auctions can be made with non-zora media. For now, removing the validation functionality makes sense both from an interoperability standpoint along with a bundle size standpoint