### PR TITLE
remove caching on dataloader env, use swr for caching, dataloader for batching

### DIFF
--- a/src/fetcher/MediaFetchAgent.ts
+++ b/src/fetcher/MediaFetchAgent.ts
@@ -73,12 +73,17 @@ export class MediaFetchAgent {
     this.networkId = network;
 
     this.loaders = {
-      mediaLoader: new DataLoader((keys) => this.fetchMediaGraph(keys)),
-      currencyLoader: new DataLoader((keys) => this.fetchCurrenciesGraph(keys)),
+      mediaLoader: new DataLoader((keys) => this.fetchMediaGraph(keys), { cache: false }),
+      currencyLoader: new DataLoader((keys) => this.fetchCurrenciesGraph(keys), {
+        cache: false,
+      }),
       usernameLoader: new DataLoader((keys) => this.fetchZoraUsernames(keys)),
-      genericNFTLoader: new DataLoader((keys) => this.fetchGenericNFT(keys)),
+      genericNFTLoader: new DataLoader((keys) => this.fetchGenericNFT(keys), {
+        cache: false,
+      }),
       auctionInfoLoader: new DataLoader((keys) => this.fetchAuctionNFTInfo(keys), {
         maxBatchSize: 1,
+        cache: false,
       }),
     };
   }

--- a/tests/__snapshots__/useZNFT.test.ts.snap
+++ b/tests/__snapshots__/useZNFT.test.ts.snap
@@ -1893,7 +1893,7 @@ Object {
         "prettyAmount": "1.2974e-14",
       },
       "status": "Active",
-      "tokenId": 2974,
+      "tokenId": "-1",
       "tokenOwner": Object {
         "id": "10",
       },
@@ -1928,7 +1928,7 @@ Object {
     "perpetual": Object {
       "ask": Object {
         "createdAtTimestamp": "12974",
-        "id": "2",
+        "id": "0",
         "pricing": Object {
           "amount": "12974",
           "computedValue": undefined,
@@ -1941,41 +1941,8 @@ Object {
           "prettyAmount": "1.2974e-14",
         },
       },
-      "bids": Array [
-        Object {
-          "bidder": Object {
-            "id": "10",
-          },
-          "createdAtTimestamp": "12974",
-          "id": "3",
-          "pricing": Object {
-            "amount": "10000",
-            "computedValue": undefined,
-            "currency": Object {
-              "decimals": 18,
-              "id": "0xFACE",
-              "name": "Wrapped Ether",
-              "symbol": "WETH",
-            },
-            "prettyAmount": "1e-14",
-          },
-        },
-      ],
-      "highestBid": Object {
-        "placedAt": "12974",
-        "placedBy": "10",
-        "pricing": Object {
-          "amount": "10000",
-          "computedValue": undefined,
-          "currency": Object {
-            "decimals": 18,
-            "id": "0xFACE",
-            "name": "Wrapped Ether",
-            "symbol": "WETH",
-          },
-          "prettyAmount": "1e-14",
-        },
-      },
+      "bids": Array [],
+      "highestBid": undefined,
     },
     "reserve": Object {
       "approved": true,
@@ -2031,7 +1998,7 @@ Object {
       "expectedEndTimestamp": "12974",
       "finalizedAtTimestamp": "12974",
       "firstBidTime": "12974",
-      "id": "4",
+      "id": "1",
       "previousBids": Array [
         Object {
           "bidInactivatedAtBlockNumber": "12974",
@@ -2041,7 +2008,7 @@ Object {
             "id": "10",
           },
           "createdAtTimestamp": "12974",
-          "id": "7",
+          "id": "4",
           "pricing": Object {
             "amount": "12974",
             "computedValue": undefined,
@@ -2062,7 +2029,7 @@ Object {
             "id": "10",
           },
           "createdAtTimestamp": "12974",
-          "id": "8",
+          "id": "5",
           "pricing": Object {
             "amount": "12974",
             "computedValue": undefined,
@@ -2088,7 +2055,7 @@ Object {
         "prettyAmount": "1.2974e-14",
       },
       "status": "Active",
-      "tokenId": 2974,
+      "tokenId": "-1",
       "tokenOwner": Object {
         "id": "10",
       },


### PR DESCRIPTION
Right now we use:

1. Dataloader: handles batching requests to graphQL, deduplication, has caching built-in and on by default
2. useSWR: caches requests, handles invalidation automatically, handles error states and data types

This diff disabled dataloader caching in favor of using useSWR for caching while using dataloader for batching and deduplication.