### PR TITLE
fix opensea max results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/nft-hooks",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Generic Rendering Component for zNFTs",
   "repository": "https://github.com/ourzora/nft-hooks",
   "homepage": "https://github.com/ourzora/nft-hooks#README",

--- a/src/fetcher/MediaFetchAgent.ts
+++ b/src/fetcher/MediaFetchAgent.ts
@@ -82,6 +82,7 @@ export class MediaFetchAgent {
       usernameLoader: new DataLoader((keys) => this.fetchZoraUsernames(keys)),
       genericNFTLoader: new DataLoader((keys) => this.fetchGenericNFT(keys), {
         cache: false,
+        maxBatchSize: 50,
       }),
       auctionInfoLoader: new DataLoader((keys) => this.fetchAuctionNFTInfo(keys), {
         cache: false,
@@ -341,7 +342,7 @@ export class MediaFetchAgent {
         urlParams.push(`token_ids=${tokenId}&asset_contract_addresses=${address}`);
       });
     const response = await fetchWithTimeout.fetch(
-      `${apiBase}assets?${urlParams.join('&')}&order_direction=desc&offset=0&limit=100`
+      `${apiBase}assets?${urlParams.join('&')}&order_direction=desc&offset=0&limit=50`
     );
     const responseJson = await response.json();
 

--- a/tests/useOpenseaNFT.test.ts
+++ b/tests/useOpenseaNFT.test.ts
@@ -31,7 +31,7 @@ describe('useZNFT', () => {
     );
 
     fetchMock.once(
-      'https://api.opensea.io/api/v1/assets?token_ids=5683&asset_contract_addresses=0xb7f7f6c52f2e2fdb1963eab30438024864c313f6&order_direction=desc&offset=0&limit=100',
+      'https://api.opensea.io/api/v1/assets?token_ids=5683&asset_contract_addresses=0xb7f7f6c52f2e2fdb1963eab30438024864c313f6&order_direction=desc&offset=0&limit=50',
       OpenseaCryptopunk
     );
 


### PR DESCRIPTION
Change batch fetches to limiting results number to 50.

This prevents the opensea API from failing when too many records are fetched.