### PR TITLE
fix limit on opensea request uri length

### DIFF
--- a/src/fetcher/MediaFetchAgent.ts
+++ b/src/fetcher/MediaFetchAgent.ts
@@ -82,7 +82,7 @@ export class MediaFetchAgent {
       usernameLoader: new DataLoader((keys) => this.fetchZoraUsernames(keys)),
       genericNFTLoader: new DataLoader((keys) => this.fetchGenericNFT(keys), {
         cache: false,
-        maxBatchSize: 50,
+        maxBatchSize: 30,
       }),
       auctionInfoLoader: new DataLoader((keys) => this.fetchAuctionNFTInfo(keys), {
         cache: false,


### PR DESCRIPTION
Opensea has a url length limit that we're hitting for more than 40 records. This reduces the limit to solve this request failure.