### PR TITLE
Convert IPFS protocol to HTTPS when fetching mime type

### DIFF
--- a/src/fetcher/MediaFetchAgent.ts
+++ b/src/fetcher/MediaFetchAgent.ts
@@ -173,9 +173,12 @@ export class MediaFetchAgent {
    * @throws RequestError
    */
   async fetchContentMimeType(url: string): Promise<string> {
-    const response = await new FetchWithTimeout(this.timeouts.IPFS).fetch(url, {
-      method: 'HEAD',
-    });
+    const response = await new FetchWithTimeout(this.timeouts.IPFS).fetch(
+      convertURIToHTTPS(url),
+      {
+        method: 'HEAD',
+      }
+    );
     const header = response.headers.get('content-type');
     if (!header) {
       throw new RequestError('No content type returned for URI');


### PR DESCRIPTION
Fixes a small issue observed when `animation_url` is using IPFS protocol, which causes a CORS error (which I think is hiding the underlying protocol error) when fetching the raw IPFS uri when resolving the mime type.