### PR TITLE
Remove offset from opensea

### DIFF
--- a/src/backends/opensea/OpenseaDataSource.ts
+++ b/src/backends/opensea/OpenseaDataSource.ts
@@ -98,9 +98,9 @@ export class OpenseaDataSource implements OpenseaInterface {
       urlParams.push(`token_ids=${tokenId}&asset_contract_addresses=${address}`);
     });
     const response = await new FetchWithTimeout(this.timeout).fetch(
-      `${this.endpoint}assets?${urlParams.join(
-        '&'
-      )}&order_direction=desc&offset=0&limit=${this.MAX_OPENSEA_SIZE}`,
+      `${this.endpoint}assets?${urlParams.join('&')}&order_direction=desc&limit=${
+        this.MAX_OPENSEA_SIZE
+      }`,
       { headers: { 'X-API-KEY': '2f6f419a083c46de9d83ce3dbe7db601' } }
     );
     const responseJson = (await response.json()) as OpenseaDataResponse;


### PR DESCRIPTION
Opensea API does not allow offset for requests that do not contain an API key. To keep compatibility offset has been removed.