### PR TITLE
Adds media to ZoraIndexerV1DataSource

### DIFF
--- a/src/backends/zora-indexer-v1/ZoraIndexerV1DataSource.ts
+++ b/src/backends/zora-indexer-v1/ZoraIndexerV1DataSource.ts
@@ -30,6 +30,7 @@ import {
   FIXED_SIDE_TYPES,
   MARKET_INFO_STATUSES,
   MARKET_TYPES,
+  MEDIA_SOURCES,
   MetadataAttributeType,
   NFTIdentifier,
   NFTObject,
@@ -436,6 +437,16 @@ export class ZoraIndexerV1DataSource implements ZoraIndexerV1Interface {
       imageUri: metadata_json.image,
       attributes: getAttributes(metadata_json),
       raw: asset.metadata?.json,
+    };
+    object.media = {
+      content: asset.media?.contentURI
+        ? {
+            uri: asset.media?.contentURI,
+          }
+        : null,
+      thumbnail: null,
+      image: null,
+      source: MEDIA_SOURCES.ZORA,
     };
     if (!object.rawData) {
       object.rawData = {};


### PR DESCRIPTION
Adds media data to ZoraIndexerV1DataSource NFTObject. Was running into some issues where NFTs from this data source would not render properly and adding media data to the return object fixed them.