### PR TITLE
Fixes issues with zdk data

### DIFF
--- a/src/backends/zdk/ZDKDataSource.ts
+++ b/src/backends/zdk/ZDKDataSource.ts
@@ -205,7 +205,7 @@ export class ZDKDataSource implements ZDKDataInterface {
         response.tokens.nodes.find(
           (token) =>
             token.token.tokenId === key.id &&
-            token.token.collectionAddress === key.contract
+            token.token.collectionAddress.toLowerCase() === key.contract.toLowerCase()
         ) || new NotFoundError('Missing record')
       );
     });

--- a/src/backends/zdk/transformUtils/processMarkets.ts
+++ b/src/backends/zdk/transformUtils/processMarkets.ts
@@ -144,7 +144,7 @@ export function processMarkets(markets: MarketResponseFragmentItem[]) {
             : undefined,
         ...getStandardMarketData({
           market,
-          amount: market.properties.reservePrice || market.properties.highestBidPrice,
+          amount: market.properties.highestBidPrice || market.properties.reservePrice,
         }),
       });
     }


### PR DESCRIPTION
Reserve price was taking priority over highest bid in processMarkets leading to incorrectly displayed data at the component level. 

ZDKDataSource was not matching collection addresses due to casing differences between passed in addresses and the graphql return address, added toLowerCase calls to fix.
