### PR TITLE
feat: update default indexer data fetching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const zdkStrategy = Strategies.ZDKFetchStrategy();
 
 function NFTGallery() {
   return (
-    <NFTFetchConfiguration strategy={zdkStrategy} network={Networks.MAINNET}>
+    <NFTFetchConfiguration strategy={zdkStrategy} networkId={Networks.MAINNET}>
       <NFTList>
     </NFTFetchConfiguration>
   );

--- a/src/context/NFTFetchContext.tsx
+++ b/src/context/NFTFetchContext.tsx
@@ -3,19 +3,19 @@ import React, { useMemo } from 'react';
 import { MediaFetchAgent } from '../fetcher/MediaFetchAgent';
 import { NFTStrategy } from '../strategies/NFTStrategy';
 import { NetworkIDs, Networks } from '../constants/networks';
-import { ZoraV2IndexerStrategy } from '../strategies';
+import { ZDKFetchStrategy } from '../strategies';
 
 export type FetchContext = { strategy: typeof NFTStrategy };
 
 const defaultNetwork = Networks.MAINNET;
 
 export const defaultFetchAgent: { strategy: any; fetcher: any } = {
-  strategy: new ZoraV2IndexerStrategy(defaultNetwork),
+  strategy: new ZDKFetchStrategy(defaultNetwork),
   fetcher: new MediaFetchAgent(defaultNetwork),
 };
 
 export const NFTFetchContext = React.createContext<{
-  strategy: NFTStrategy | ZoraV2IndexerStrategy;
+  strategy: NFTStrategy | ZDKFetchStrategy;
   fetcher: MediaFetchAgent;
 }>(defaultFetchAgent);
 
@@ -34,7 +34,7 @@ export const NFTFetchConfiguration = ({
     if (userStrategy) {
       return userStrategy;
     }
-    return new ZoraV2IndexerStrategy(networkId);
+    return new ZDKFetchStrategy(networkId);
   }, [userStrategy]);
 
   const fetcher = useMemo(() => {


### PR DESCRIPTION
In the readme at the time of https://github.com/ourzora/nft-hooks/commit/41e02456dc8e400f1583b334345fcbe052abbc7b  (and the latest `main` branch release at the time of the writing), it was recommended to use `ZDKFetchStrategy` instead of the deprecated `ZoraV2Indexer` after v1 release of the hook.

Found out this when I need to explicitly override the fetching strategy with `zdk` in `nft-component` in order for the result to show up. Updating the default strategy with the recommended indexer.

Also update the prop types in the readme to latest.